### PR TITLE
Properly close watches when a node is removed

### DIFF
--- a/pkg/server/delta/v3/watches.go
+++ b/pkg/server/delta/v3/watches.go
@@ -26,9 +26,7 @@ func newWatches() watches {
 // Cancel all watches
 func (w *watches) Cancel() {
 	for _, watch := range w.deltaWatches {
-		if watch.cancel != nil {
-			watch.cancel()
-		}
+		watch.Cancel()
 	}
 }
 
@@ -46,5 +44,9 @@ func (w *watch) Cancel() {
 	if w.cancel != nil {
 		w.cancel()
 	}
-	close(w.responses)
+	if w.responses != nil {
+		// w.responses should never be used by a producer once cancel() has been closed, so we can safely close it here
+		// This is needed to release resources taken by goroutines watching this channel
+		close(w.responses)
+	}
 }

--- a/pkg/server/delta/v3/watches_test.go
+++ b/pkg/server/delta/v3/watches_test.go
@@ -1,0 +1,42 @@
+package delta
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+)
+
+func TestDeltaWatches(t *testing.T) {
+	t.Run("watches response channels are properly closed when the watches are cancelled", func(t *testing.T) {
+		watches := newWatches()
+
+		cancelCount := 0
+		var channels []chan cache.DeltaResponse
+		// create a few watches, and ensure that the cancel function are called and the channels are closed
+		for i := 0; i < 5; i++ {
+			newWatch := watch{}
+			if i%2 == 0 {
+				newWatch.cancel = func() { cancelCount++ }
+				newWatch.responses = make(chan cache.DeltaResponse)
+				channels = append(channels, newWatch.responses)
+			}
+
+			watches.deltaWatches[strconv.Itoa(i)] = newWatch
+		}
+
+		watches.Cancel()
+
+		assert.Equal(t, 3, cancelCount)
+		for _, channel := range channels {
+			select {
+			case _, ok := <-channel:
+				assert.False(t, ok, "a channel was not closed")
+			default:
+				assert.Fail(t, "a channel was not closed")
+			}
+		}
+	})
+}


### PR DESCRIPTION
We noticed on our environments that control-planes getting no activity outside of serving xds through delta-ads to a constant nb of pods had an ever-growing consumption of memory
Investigating further we noticed that:
- this memory increase correlated to a nb of goroutine increase (even if the nb of clients is constant)
- the increase occur each time we restart those client pods (done on purpose to test some edge cases)
- the increase is two goroutines per pod, which makes sense as those use lds and cds as dynamic resources and do not trigger rds, eds or rtds watches

Taking a goroutine dump we identified that leaked goroutines are from https://github.com/envoyproxy/go-control-plane/blob/main/pkg/server/delta/v3/server.go#L180
Those goroutines will only be gc-ed once the channel has either returned a response or been closed. This closure is expected to happen in `watch.Cancel()`, but in the case of a node getting removed, we are actually calling the potentially set `cancel` function attached to the watch, but we do not close this channel

Disclaimer: we use a slightly different fork of the repository. While I do not believe it impacts here, we are not using vanilla control-plane today