### PR TITLE
Properly support adding/removing resources and getting updates from them

### DIFF
--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -85,6 +85,8 @@ type Response interface {
 	// Get the version in the Response.
 	GetVersion() (string, error)
 
+	GetResourceNames() []string
+
 	// Get the context provided during response creation.
 	GetContext() context.Context
 }
@@ -121,6 +123,9 @@ type RawResponse struct {
 
 	// Resources to be included in the response.
 	Resources []types.ResourceWithTTL
+
+	// Names of the resources included in the response
+	ResourceNames []string
 
 	// Whether this is a heartbeat response. For xDS versions that support TTL, this
 	// will be converted into a response that doesn't contain the actual resource protobuf.
@@ -170,6 +175,8 @@ type PassthroughResponse struct {
 
 	// The discovery response that needs to be sent as is, without any marshaling transformations.
 	DiscoveryResponse *discovery.DiscoveryResponse
+
+	ResourceNames []string
 
 	ctx context.Context
 }
@@ -225,6 +232,10 @@ func (r *RawResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, erro
 	}
 
 	return marshaledResponse.(*discovery.DiscoveryResponse), nil
+}
+
+func (r *RawResponse) GetResourceNames() []string {
+	return r.ResourceNames
 }
 
 // GetDeltaDiscoveryResponse performs the marshaling the first time its called and uses the cached response subsequently.
@@ -328,6 +339,11 @@ func (r *RawResponse) maybeCreateTTLResource(resource types.ResourceWithTTL) (ty
 // GetDiscoveryResponse returns the final passthrough Discovery Response.
 func (r *PassthroughResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
 	return r.DiscoveryResponse, nil
+}
+
+// GetResourceNames returns the list of resources included within the response
+func (r *PassthroughResponse) GetResourceNames() []string {
+	return r.ResourceNames
 }
 
 // GetDeltaDiscoveryResponse returns the final passthrough Delta Discovery Response.

--- a/pkg/server/delta/v3/server.go
+++ b/pkg/server/delta/v3/server.go
@@ -245,6 +245,11 @@ func (s *server) unsubscribe(resources []string, streamState *stream.StreamState
 			// * detect the version change, and return the resource (as an update)
 			// * detect the resource deletion, and set it as removed in the response
 			streamState.GetResourceVersions()[resource] = ""
+		} else {
+			// Clean-up the state version for this resource.
+			// This addresses https://github.com/envoyproxy/go-control-plane/issues/583, where a resource unsubscribed then subscribed again
+			// is not sent again while envoy expects it.
+			delete(streamState.GetResourceVersions(), resource)
 		}
 		delete(sv, resource)
 	}

--- a/pkg/server/v3/delta_test.go
+++ b/pkg/server/v3/delta_test.go
@@ -468,7 +468,7 @@ func TestDeltaWildcardSubscriptions(t *testing.T) {
 		},
 	}
 
-	validateResponse := func(t *testing.T, replies <-chan *discovery.DeltaDiscoveryResponse, expectedResources []string, expectedRemovedResources []string) {
+	validateResponse := func(t *testing.T, replies <-chan *discovery.DeltaDiscoveryResponse, expectedResources []string, expectedRemovedResources []string) string {
 		t.Helper()
 		select {
 		case response := <-replies:
@@ -481,8 +481,10 @@ func TestDeltaWildcardSubscriptions(t *testing.T) {
 				assert.ElementsMatch(t, names, expectedResources)
 				assert.ElementsMatch(t, response.RemovedResources, expectedRemovedResources)
 			}
+			return response.GetNonce()
 		case <-time.After(1 * time.Second):
 			t.Fatalf("got no response")
+			return ""
 		}
 	}
 
@@ -529,6 +531,41 @@ func TestDeltaWildcardSubscriptions(t *testing.T) {
 		}
 		validateResponse(t, resp.sent, []string{"endpoints0"}, nil)
 
+	})
+
+	t.Run("unsubscribed resources are sent again if re-subscribed later on and the version has not changed", func(t *testing.T) {
+		resp := makeMockDeltaStream(t)
+		defer close(resp.recv)
+		s := server.NewServer(context.Background(), config, server.CallbackFuncs{})
+		go func() {
+			err := s.DeltaAggregatedResources(resp)
+			assert.NoError(t, err)
+		}()
+
+		resp.recv <- &discovery.DeltaDiscoveryRequest{
+			Node:                   node,
+			TypeUrl:                rsrc.EndpointType,
+			ResourceNamesSubscribe: []string{"endpoints0", "endpoints1"},
+		}
+		nonce := validateResponse(t, resp.sent, []string{"endpoints0", "endpoints1"}, nil)
+
+		// Unsubscribe from endpoints0
+		resp.recv <- &discovery.DeltaDiscoveryRequest{
+			Node:                     node,
+			TypeUrl:                  rsrc.EndpointType,
+			ResponseNonce:            nonce,
+			ResourceNamesUnsubscribe: []string{"endpoints0"},
+		}
+		// No reply is expected here
+
+		// Subscribe again to endpoints0
+		resp.recv <- &discovery.DeltaDiscoveryRequest{
+			Node:                   node,
+			TypeUrl:                rsrc.EndpointType,
+			ResponseNonce:          nonce,
+			ResourceNamesSubscribe: []string{"endpoints0"},
+		}
+		validateResponse(t, resp.sent, []string{"endpoints0"}, nil)
 	})
 
 	t.Run("* subscribtion/unsubscription support", func(t *testing.T) {

--- a/pkg/server/v3/server.go
+++ b/pkg/server/v3/server.go
@@ -29,7 +29,6 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	clusterservice "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	discoverygrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	endpointservice "github.com/envoyproxy/go-control-plane/envoy/service/endpoint/v3"
 	extensionconfigservice "github.com/envoyproxy/go-control-plane/envoy/service/extension/v3"
 	listenerservice "github.com/envoyproxy/go-control-plane/envoy/service/listener/v3"
@@ -48,7 +47,7 @@ type Server interface {
 	routeservice.ScopedRoutesDiscoveryServiceServer
 	routeservice.VirtualHostDiscoveryServiceServer
 	listenerservice.ListenerDiscoveryServiceServer
-	discoverygrpc.AggregatedDiscoveryServiceServer
+	discovery.AggregatedDiscoveryServiceServer
 	secretservice.SecretDiscoveryServiceServer
 	runtimeservice.RuntimeDiscoveryServiceServer
 	extensionconfigservice.ExtensionConfigDiscoveryServiceServer
@@ -184,7 +183,7 @@ func (s *server) StreamHandler(stream stream.Stream, typeURL string) error {
 	return s.sotw.StreamHandler(stream, typeURL)
 }
 
-func (s *server) StreamAggregatedResources(stream discoverygrpc.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
+func (s *server) StreamAggregatedResources(stream discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
 	return s.StreamHandler(stream, resource.AnyType)
 }
 
@@ -297,7 +296,7 @@ func (s *server) DeltaStreamHandler(stream stream.DeltaStream, typeURL string) e
 	return s.delta.DeltaStreamHandler(stream, typeURL)
 }
 
-func (s *server) DeltaAggregatedResources(stream discoverygrpc.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {
+func (s *server) DeltaAggregatedResources(stream discovery.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {
 	return s.DeltaStreamHandler(stream, resource.AnyType)
 }
 


### PR DESCRIPTION
This PR is handling https://github.com/envoyproxy/go-control-plane/issues/583
This issue is impacting both sotw and delta with linear cache

Multiple aspects here:
- delta with linear cache does not currently implement ack/nack. It should be feasible reusing the new streamState attributes here quite easily
- sotw with LinearCache does handle two cases very differently
  - wildcard: will always send all resources as long as the version doesn't match. This is anyway mandatory given how envoy implements cds/lds. I don't have a clear use case for this (the wildcard feature of cds makes it hardly usable with a linear cache). This might change if Simple cache is reimplemented as LinearCaches per id
  - specified resources: only send changed resources. This is mainly used for EDS and sending all endpoints at once each time can put quite a lot of pressure on envoy. This PR keeps this behavior

In the end, this PR includes:
- for delta + linear, ensures an unsubscribed resource is removed from knownResources, so when subscribed again it will be sent in the response, fixing the issue
- for simple cache (delta and sotw): use the common GetResourceVersions instead of GetKnownResourceNames to be compatible with both sotw and delta. Those two distinct attributes representing the same thing is a pain to maintain. Also returns the resourceNames
- for sotw + linear: 
  - fixes a bug when the request passed with the response was not the actual request. It was actually used in the server code, and was fully wrong
  - fixes a potentially critical bug when a watch refers to multiple resources and updates are sent for only single resources one by one. The watch was only deleted from the updated resource, leaking it in other resources. When those end up updated later on they will queue in the channel which is no longer listened to. As it is buffered by 1 it would accept the first update then deadlock further updates
  - updated to return resourceNames in the response to properly keep track of what was returned to the user (which may not be what was returned)
  - properly consider the resources added even if the version isn't changed (which is how envoy seems to process it), and whether it was subscribed to before or not
- sotw in general:
  - replaces the parallel lastResponse part with staged resources within the streamState. This will also be applicable for delta to properly support ACK/NACK mechanism
  -  